### PR TITLE
Fixing CVE for golang-jwt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ ARG JAVA_VERSION=21.0.4+7
 ARG NODE_VERSION=20.17.0
 ARG PROTO_VERSION=28.2
 ARG GO_VERSION=1.22.7
-ARG GO_MIGRATE_VERSION=4.18.2
 ARG GRADLE_VERSION=8.5
 ARG WASMER_VERSION=4.3.7
 ARG BASE_IMAGE=ubuntu:24.04
@@ -42,7 +41,7 @@ RUN apt-get update && apt-get install -y \
     libgomp1 \
     xz-utils \
     && apt-get clean
-  
+
 # Install JDK
 RUN JAVA_ARCH=$( if [ "$TARGETARCH" = "arm64" ]; then echo -n "aarch64"; else echo -n "x64"; fi ) && \
     curl -sLo - https://api.adoptium.net/v3/binary/version/jdk-${JAVA_VERSION}/${TARGETOS}/${JAVA_ARCH}/jdk/${JVM_TYPE}/${JVM_HEAP}/eclipse | \
@@ -58,7 +57,7 @@ RUN NODE_ARCH=$( if [ "$TARGETARCH" = "arm64" ]; then echo -n "arm64"; else echo
 # Install Protoc
 RUN PROTO_ARCH=$( if [ "$TARGETARCH" = "arm64" ]; then echo -n "aarch_64"; else echo -n "x86_64"; fi ) && \
     curl -sLo protoc-$PROTO_VERSION-${TARGETOS}-${PROTO_ARCH}.zip \
-      https://github.com/protocolbuffers/protobuf/releases/download/v$PROTO_VERSION/protoc-$PROTO_VERSION-${TARGETOS}-${PROTO_ARCH}.zip && \
+    https://github.com/protocolbuffers/protobuf/releases/download/v$PROTO_VERSION/protoc-$PROTO_VERSION-${TARGETOS}-${PROTO_ARCH}.zip && \
     unzip protoc-$PROTO_VERSION-${TARGETOS}-${PROTO_ARCH}.zip -d /usr/local/protoc && \
     rm protoc-$PROTO_VERSION-${TARGETOS}-${PROTO_ARCH}.zip
 
@@ -138,6 +137,12 @@ COPY operator/go.mod operator/go.mod
 COPY perf/go.mod perf/go.mod
 RUN gradle --no-daemon --parallel assemble
 
+# Build go migrate tool
+WORKDIR /build
+RUN git clone https://github.com/golang-migrate/migrate.git && \
+    cd migrate && \
+    make build-docker
+
 # SBOM
 FROM alpine:3.19 AS sbom
 WORKDIR /
@@ -147,15 +152,6 @@ RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/
 RUN trivy fs --format spdx-json --output /sbom.spdx.json /SBOM
 RUN trivy sbom /sbom.spdx.json --severity UNKNOWN,HIGH,CRITICAL --db-repository public.ecr.aws/aquasecurity/trivy-db --exit-code 1
 
-# GOMIGRATE - build due to CVE
-#FROM  golang:1.22-bookworm AS gomigratebuilder
-#ENV GO111MODULE=on
-#RUN apt update && apt install git jq build-essential -y
-#WORKDIR /build
-#RUN git clone https://github.com/golang-migrate/migrate.git && \
-#   cd migrate && \
-#    make build-docker && \
-#   ls
 
 # Stage 3: Pull together runtime
 FROM $BASE_IMAGE AS runtime
@@ -165,7 +161,6 @@ ARG TARGETARCH
 ARG JAVA_VERSION
 ARG JVM_TYPE
 ARG JVM_HEAP
-ARG GO_MIGRATE_VERSION
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
@@ -187,13 +182,9 @@ RUN JAVA_ARCH=$( if [ "$TARGETARCH" = "arm64" ]; then echo -n "aarch64"; else ec
     tar -C /usr/local -xzf - && \
     ln -s /usr/local/jdk-* /usr/local/java
 
-
-# Install DB migration tool
- RUN GO_MIRGATE_ARCH=$( if [ "$TARGETARCH" = "arm64" ]; then echo -n "arm64"; else echo -n "amd64"; fi ) && \
-     curl -sLo - https://github.com/golang-migrate/migrate/releases/download/v$GO_MIGRATE_VERSION/migrate.${TARGETOS}-${GO_MIRGATE_ARCH}.tar.gz | \
-    tar -C /usr/local/bin -xzf - migrate
-#COPY --from=gomigratebuilder /build/migrate/build/migrate.linux-386 /usr/local/bin/migrate
-#RUN chmod +x /usr/local/bin/migrate
+# Copy the migrate tool
+COPY --from=full-builder /build/migrate/build/migrate.linux-386 /usr/local/bin/migrate
+RUN chmod +x /usr/local/bin/migrate
 
 # Copy Wasmer shared libraries to the runtime container
 COPY --from=full-builder /usr/local/wasmer/lib/libwasmer.so /usr/local/wasmer/lib/libwasmer.so
@@ -219,4 +210,4 @@ ENTRYPOINT [                         \
     "-Djna.library.path=/app/libs",  \
     "-jar",                          \
     "/app/libs/paladin.jar"          \
-]
+    ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,9 @@ RUN gradle --no-daemon --parallel assemble
 
 # Build go migrate tool
 WORKDIR /build
-RUN git clone https://github.com/golang-migrate/migrate.git && \
+RUN GOOS=linux && \
+    GOARCH=$( if [ "$TARGETARCH" = "arm64" ]; then echo -n "arm64"; else echo -n "amd64"; fi  ) && \
+    git clone https://github.com/golang-migrate/migrate.git && \
     cd migrate && \
     make build-docker
 


### PR DESCRIPTION
Update the Dockerfile to build go migrate inline as there isn't a new version of go migrate available for CVE https://avd.aquasec.com/nvd/2025/cve-2025-30204/