### PR TITLE
Add 27 to V

### DIFF
--- a/signingmodules/kaleidokms/internal/keymanagersigningmodule/key_manager_signing_module.go
+++ b/signingmodules/kaleidokms/internal/keymanagersigningmodule/key_manager_signing_module.go
@@ -299,6 +299,7 @@ func (rsm *keyManagerSigningModule) Sign(ctx context.Context, req *prototk.SignW
 	if len(payloadBytes) != 65 {
 		return nil, i18n.NewError(ctx, msgs.MsgSignInvalidSignatureLength, len(payloadBytes))
 	}
+	payloadBytes[64] = payloadBytes[64] + 27
 
 	return &prototk.SignWithKeyResponse{
 		Payload: payloadBytes,

--- a/signingmodules/kaleidokms/internal/keymanagersigningmodule/key_manager_signing_module_test.go
+++ b/signingmodules/kaleidokms/internal/keymanagersigningmodule/key_manager_signing_module_test.go
@@ -666,6 +666,7 @@ func TestSignOkECDSA_SECP256K1(t *testing.T) {
 	// Use deterministic bytes instead of random bytes for consistent test results
 	payloadRespBase64 := "72ujCh4Eg8gl4+PpjQ9aAZovHshn5X1yv1j0t2jCTzg3GswBSu1c/6NsWCxGIJTXaGiXYGUK2kIODSRbDu+3mgE="
 	expectedPayloadBytes, err := base64.StdEncoding.DecodeString(payloadRespBase64)
+	expectedPayloadBytes[64] = expectedPayloadBytes[64] + 27
 	require.NoError(t, err)
 
 	ctx, httpEndpoint, done := newTestServer(t, func(r *http.Request) (int, interface{}) {


### PR DESCRIPTION
Mapping the recovery byte from the RSV sig that KMS returns to the Ethereum values of 27/28 by adding 27.

Need to consider whether this is the right place longer term but this is the most convenient place to put the mapping right now.