### PR TITLE
use option to auto create public identifiers

### DIFF
--- a/signingmodules/kaleidokms/internal/keymanagersigningmodule/kms_types.go
+++ b/signingmodules/kaleidokms/internal/keymanagersigningmodule/kms_types.go
@@ -27,6 +27,7 @@ type ResolveKeyRequest struct {
 	PublicIdentifierTypesToResolve []string       `json:"publicIdentifierTypesToResolve,omitempty"`
 	KeySpec                        string         `json:"spec,omitempty"`
 	AutoKeyCreation                bool           `json:"autoKeyCreation"`
+	AutoPublicIdentifiersCreation  bool           `json:"autoPublicIdentifierCreation"`
 }
 
 type ResolveKeyResponse struct {
@@ -53,9 +54,4 @@ type KeyIdentifier struct {
 type PublicIdentifier struct {
 	Type  string `json:"type"`
 	Value string `json:"value"`
-}
-
-type PublicIdentifierCreationInput struct {
-	KeyID string `json:"keyId"`
-	Type  string `json:"type"`
 }


### PR DESCRIPTION
Apparently I can't read/scroll down and completely missed this option in my first delivery of the plugin.

There's no need to work around public identifiers not being created. You just have to set the right option to do so.