### PR TITLE
Introduce transport_queryPeers

### DIFF
--- a/core/go/internal/transportmgr/peer.go
+++ b/core/go/internal/transportmgr/peer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Kaleido, Inc.
+ * Copyright contributors to Paladin, an LFDT project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -102,15 +102,6 @@ func (tm *transportManager) listActivePeers() nameSortedPeers {
 	}
 	sort.Sort(peers)
 	return peers
-}
-
-func (tm *transportManager) listActivePeerInfo() []*pldapi.PeerInfo {
-	peers := tm.listActivePeers()
-	peerInfo := make([]*pldapi.PeerInfo, len(peers))
-	for i, p := range peers {
-		peerInfo[i] = &p.PeerInfo
-	}
-	return peerInfo
 }
 
 func (tm *transportManager) getPeerInfo(nodeName string) *pldapi.PeerInfo {

--- a/core/go/internal/transportmgr/transportmgr_rpc.go
+++ b/core/go/internal/transportmgr/transportmgr_rpc.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Kaleido, Inc.
+// Copyright contributors to Paladin, an LFDT project
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,8 +34,7 @@ func (tm *transportManager) initRPC() {
 		Add("transport_nodeName", tm.rpcNodeName()).
 		Add("transport_localTransports", tm.rpcLocalTransports()).
 		Add("transport_localTransportDetails", tm.rpcLocalTransportDetails()).
-		Add("transport_peers", tm.rpcPeers()).
-		Add("transport_peersWithQuery", tm.rpcPeersWithQuery()).
+		Add("transport_queryPeers", tm.rpcQueryPeers()).
 		Add("transport_peerInfo", tm.rpcPeerInfo()).
 		Add("transport_queryReliableMessages", tm.rpcQueryReliableMessages()).
 		Add("transport_queryReliableMessageAcks", tm.rpcQueryReliableMessageAcks())
@@ -66,14 +65,7 @@ func (tm *transportManager) rpcLocalTransportDetails() rpcserver.RPCHandler {
 	})
 }
 
-func (tm *transportManager) rpcPeers() rpcserver.RPCHandler {
-	return rpcserver.RPCMethod0(func(ctx context.Context) ([]*pldapi.PeerInfo, error) {
-		// ctx = log.WithComponent(ctx, "transportmanager")
-		return tm.listActivePeerInfo(), nil
-	})
-}
-
-func (tm *transportManager) rpcPeersWithQuery() rpcserver.RPCHandler {
+func (tm *transportManager) rpcQueryPeers() rpcserver.RPCHandler {
 	return rpcserver.RPCMethod1(func(ctx context.Context, jq query.QueryJSON) ([]*pldapi.PeerInfo, error) {
 		ctx = log.WithComponent(ctx, "transportmanager")
 		return tm.QueryPeers(ctx, &jq)

--- a/core/go/internal/transportmgr/transportmgr_rpc_test.go
+++ b/core/go/internal/transportmgr/transportmgr_rpc_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Kaleido, Inc.
+ * Copyright contributors to Paladin, an LFDT project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -67,18 +67,10 @@ func TestRPCLocalDetails(t *testing.T) {
 	_, err := tm.getPeer(ctx, "node2", false)
 	require.NoError(t, err)
 
-	peers, rpcErr := transportRPC.Peers(ctx)
+	peers, rpcErr := transportRPC.QueryPeers(ctx, query.NewQueryBuilder().Limit(100).Query())
 	require.NoError(t, rpcErr)
 	require.Len(t, peers, 1)
 	require.Equal(t, "node2", peers[0].Name)
-
-	filteredPeers, rpcErr := transportRPC.PeersWithQuery(ctx, query.NewQueryBuilder().
-		Equal("name", "node2").
-		Limit(100).
-		Query())
-	require.NoError(t, rpcErr)
-	require.Len(t, filteredPeers, 1)
-	require.Equal(t, "node2", filteredPeers[0].Name)
 
 	peer, rpcErr := transportRPC.PeerInfo(ctx, "node2")
 	require.NoError(t, rpcErr)

--- a/doc-site/docs/reference/apis/transport.md
+++ b/doc-site/docs/reference/apis/transport.md
@@ -33,13 +33,7 @@ title: transport_*
 
 0. `peer`: [`PeerInfo`](../types/peerinfo.md#peerinfo)
 
-## `transport_peers`
-
-### Returns
-
-0. `peers`: [`PeerInfo[]`](../types/peerinfo.md#peerinfo)
-
-## `transport_peersWithQuery`
+## `transport_queryPeers`
 
 ### Parameters
 

--- a/sdk/go/pkg/pldclient/transport.go
+++ b/sdk/go/pkg/pldclient/transport.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2026 Kaleido, Inc.
+ * Copyright contributors to Paladin, an LFDT project
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -28,8 +28,7 @@ type Transport interface {
 	NodeName(ctx context.Context) (nodeName string, err error)
 	LocalTransports(ctx context.Context) (transportNames []string, err error)
 	LocalTransportDetails(ctx context.Context, transportName string) (transportDetailsStr string, err error)
-	Peers(ctx context.Context) (peers []*pldapi.PeerInfo, err error)
-	PeersWithQuery(ctx context.Context, query *query.QueryJSON) (peers []*pldapi.PeerInfo, err error)
+	QueryPeers(ctx context.Context, query *query.QueryJSON) (peers []*pldapi.PeerInfo, err error)
 	PeerInfo(ctx context.Context, nodeName string) (peer *pldapi.PeerInfo, err error)
 	QueryReliableMessages(ctx context.Context, query *query.QueryJSON) (reliableMessages []*pldapi.ReliableMessage, err error)
 	QueryReliableMessageAcks(ctx context.Context, query *query.QueryJSON) (reliableMessageAcks []*pldapi.ReliableMessageAck, err error)
@@ -51,11 +50,7 @@ var transportInfo = &rpcModuleInfo{
 			Inputs: []string{"transportName"},
 			Output: "transportDetailsStr",
 		},
-		"transport_peers": {
-			Inputs: []string{},
-			Output: "peers",
-		},
-		"transport_peersWithQuery": {
+		"transport_queryPeers": {
 			Inputs: []string{"query"},
 			Output: "peers",
 		},
@@ -100,13 +95,8 @@ func (t *transport) LocalTransportDetails(ctx context.Context, transportName str
 	return
 }
 
-func (t *transport) Peers(ctx context.Context) (peers []*pldapi.PeerInfo, err error) {
-	err = t.c.CallRPC(ctx, &peers, "transport_peers")
-	return
-}
-
-func (t *transport) PeersWithQuery(ctx context.Context, query *query.QueryJSON) (peers []*pldapi.PeerInfo, err error) {
-	err = t.c.CallRPC(ctx, &peers, "transport_peersWithQuery", query)
+func (t *transport) QueryPeers(ctx context.Context, query *query.QueryJSON) (peers []*pldapi.PeerInfo, err error) {
+	err = t.c.CallRPC(ctx, &peers, "transport_queryPeers", query)
 	return
 }
 

--- a/sdk/typescript/src/paladin.ts
+++ b/sdk/typescript/src/paladin.ts
@@ -1109,14 +1109,9 @@ export default class PaladinClient {
       return res.data.result;
     },
 
-    peers: async () => {
-      const res = await this.post<JsonRpcResult<any[]>>("transport_peers", []);
-      return res.data.result;
-    },
-
-    peersWithQuery: async (query: IQuery) => {
+    queryPeers: async (query: IQuery) => {
       const res = await this.post<JsonRpcResult<any[]>>(
-        "transport_peersWithQuery",
+        "transport_queryPeers",
         [query]
       );
       return res.data.result;

--- a/ui/client/src/queries/rpcMethods.ts
+++ b/ui/client/src/queries/rpcMethods.ts
@@ -1,4 +1,4 @@
-// Copyright © 2026 Kaleido, Inc.
+// Copyright contributors to Paladin, an LFDT project
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -57,7 +57,6 @@ export const RpcMethods = {
   reg_Registries: 'reg_registries',
   transport_localTransportDetails: 'transport_localTransportDetails',
   transport_nodeName: 'transport_nodeName',
-  transport_peers: 'transport_peers',
-  transport_queryReliableMessages: 'transport_queryReliableMessages',
-  transport_peersWithQuery: 'transport_peersWithQuery'
+  transport_queryPeers: 'transport_queryPeers',
+  transport_queryReliableMessages: 'transport_queryReliableMessages'
 };

--- a/ui/client/src/queries/transport.ts
+++ b/ui/client/src/queries/transport.ts
@@ -1,4 +1,4 @@
-// Copyright © 2025 Kaleido, Inc.
+// Copyright contributors to Paladin, an LFDT project
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -74,7 +74,7 @@ export const fetchTransportPeersWithQuery = async (
   const requestPayload = {
     jsonrpc: "2.0",
     id: Date.now(),
-    method: RpcMethods.transport_peersWithQuery,
+    method: RpcMethods.transport_queryPeers,
     params: [{
       ...deepMerge(translatedFilters, customFilters),
       limit,


### PR DESCRIPTION
Replace JSON RPC methods `transport_peers` and `transport_peersWithQuery` with `transport_queryPeers` which accepts one JSON Query argument. Ensure all tests continue to pass and that code coverage remains the same. Also ensure SDK, docs and UI dependencies are updated. Update headers of affected files.