### PR TITLE
Ignore GO-2026-5932 (x/crypto/openpgp) in trivy scans

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# golang.org/x/crypto/openpgp is deprecated/unmaintained with no fixed version (GO-2026-5932).
+# No openpgp package is imported by any Paladin module or its dependencies (verified with `go mod why`).
+GO-2026-5932

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,9 @@ COPY --from=full-builder /usr/local/wasmer/lib/libwasmer.so /usr/local/wasmer/li
 # Copy the build artifacts from the builder stage
 COPY --from=full-builder /app/build /app
 
+# Trivy ignore list for risk-accepted findings, picked up by image scanners
+COPY .trivyignore /.trivyignore
+
 RUN mkdir /app/jna && chmod -R g+rwx /app/jna && chown -R 1001:1001 /app/jna
 
 USER 1001:1001

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -20,6 +20,9 @@ RUN cd operator; go build -a -o manager cmd/main.go
 FROM ubuntu:24.04
 WORKDIR /
 COPY --from=builder --chown=65532:65532 /workspace/operator/manager .
+
+# Trivy ignore list for risk-accepted findings, picked up by image scanners
+COPY .trivyignore /.trivyignore
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
The advisory marks golang.org/x/crypto/openpgp as unmaintained with no fixed version, so every version of x/crypto is flagged. No openpgp package is imported by any Paladin module or its dependencies (verified with `go mod why` across all 16 modules), so the flagged code is never compiled into any binary.